### PR TITLE
bump packages, test db connection

### DIFF
--- a/database/pgp_db.js
+++ b/database/pgp_db.js
@@ -1,22 +1,26 @@
-var promise = require('bluebird');
+const promise = require('bluebird');
 
-var options = {
+const initOptions = {
   // Initialization Options
   promiseLib: promise
 };
 
-const pgp = require('pg-promise')(options);
+const pgp = require('pg-promise')(initOptions);
 pgp.pg.types.setTypeParser(20, BigInt);
 const ctStr = require('./db_connect.json');
 
 const db = pgp(ctStr);
 
-db.proc('version')
-  .then(data => {
-    // console.log(data.version);
+db.connect()
+  .then(obj => {
+    // log server version:
+    const serverVersion = obj.client.serverVersion;
+    console.log(serverVersion);
+
+    obj.done(); // success, release the connection;
   })
   .catch(error => {
-    console.log("error connecting");
+    console.log('ERROR:', error.message || error);
   });
 
 module.exports = db;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "pre-commit": "test",
   "dependencies": {
+    "acorn": "^6.4.2",
     "bluebird": "^3.7.2",
     "body-parser": "~1.18.3",
     "cookie-parser": "^1.4.4",
@@ -16,7 +17,8 @@
     "express": "^4.17.1",
     "jade": "^1.11.0",
     "morgan": "^1.9.1",
-    "pg-promise": "^8.7.5",
+    "node-postgres": "^0.6.2",
+    "pg-promise": "^10.7.0",
     "request": "^2.88.0",
     "swagger-ui-express": "^4.1.2",
     "terraformer": "^1.0.10",


### PR DESCRIPTION
@SimonGoring cc @IceAgeEcologist 

Background:
The neotoma node api cannot be run locally, which is a huge impediment to testing and development. Initially, we believed that this was a db provisioning problem. However, based on input from Steve and development of a lightweight prototype that successfully connected to the db, we confirmed that the issue had to be in the api code.

Solution:
Bump core dependency versions (e.g., pg-promise), add db connection test, and enable the api to run locally. Many of the dependencies that are currently in dev and prod are deprecated. It's somewhat puzzling that they continue to work, but this could relate to the version of node js running on the server. 

Before Merging:
I would like to check this branch out on the dev api server and run an `npm-install` to ensure that that environment is capable of supporting the updated dependencies. @SimonGoring -- do you see any issue with this?

Note:
The db accounts that are setup for Simon and I are able to connect from any machine (assuming VPN connection). This is not true for the neotomawsreader user.