### PR TITLE
show publications related to datasetid

### DIFF
--- a/v1.5/handlers/data_handlers.js
+++ b/v1.5/handlers/data_handlers.js
@@ -276,7 +276,7 @@ function publicationquery(req, res, next) {
   var query =  "select distinct pubtype, citation, year, publicationid" +
      " from da.publications" +
      " where 1 = 1" +
-     " and publicationid = $1";
+     " and datasetid = $1";
   
   if(!datasetId){
     res.status(200)


### PR DESCRIPTION
This PR fixes the publications issue that was discovered in Explorer on November 21, 2020. The issue was that publications were being returned under the assumption that a publication id was being passed in when a dataset id should have been being passed in.