### PR TITLE
update explorer search query [time]

### DIFF
--- a/v1.5/helpers/search/search.js
+++ b/v1.5/helpers/search/search.js
@@ -193,11 +193,11 @@ function explorersearch(req, res, next) {
   */
 
   if (inputParamObj.time) {
-    if (inputParamObj.time.ageolder) {
-      qryParams._ageold = parseInt(inputParamObj.time.ageolder, 10);
+    if (inputParamObj.time.ageOlder) {
+      qryParams._ageold = parseInt(inputParamObj.time.ageOlder, 10);
     }
-    if (inputParamObj.time.ageyounger) {
-      qryParams._ageyoung = parseInt(inputParamObj.time.ageyounger, 10);
+    if (inputParamObj.time.ageYounger) {
+      qryParams._ageyoung = parseInt(inputParamObj.time.ageYounger, 10);
     }
     inputParamObj.time.resultType == "intersects" ? qryParams._agedocontain = false : qryParams._agedocontain = true;
     inputParamObj.time.exactlyDated == true ? qryParams._agedirectdate = true : qryParams._agedirectdate = false;


### PR DESCRIPTION
The explorer search query was not respecting temporal intersection filtering. The primary problem was in the db function (which has been modified with changes also reflected in the github repo). This PR makes one small change to search.js in the api to finalize the fix.