### PR TITLE
enable multiple ds and site searches

### DIFF
--- a/v1.5/handlers/data_handlers.js
+++ b/v1.5/handlers/data_handlers.js
@@ -76,9 +76,9 @@ module.exports = {
     //messy need for which or if conditional to check for which
     //query parameters have been passed
 
-    if(req.query.hasOwnProperty('siteid')){
+    if(req.query.hasOwnProperty('siteids')){
       console.log("req.query.siteid: "+req.query.siteid);
-      datasets.datasetsbysiteid(req,res,next);
+      datasets.datasetsbysiteids(req,res,next);
     } else if (req.query.hasOwnProperty('datasetids')){
        datasets.datasetbyids(req, res, next);
     } else {

--- a/v1.5/helpers/datasets/datasetbysites.sql
+++ b/v1.5/helpers/datasets/datasetbysites.sql
@@ -1,16 +1,20 @@
 SELECT 
-    json_build_object(       'siteid', sts.siteid, 
-                              'sitename', sts.sitename,
-                       'sitedescription', sts.sitedescription,
-                             'sitenotes', sts.notes,
-                             'geography', ST_AsGeoJSON(sts.geog,5,2),
-                              'altitude', sts.altitude, 
-                              'unittype', cts.colltype) as site,
+    json_build_object(  'siteid', sts.siteid, 
+                        'sitename', sts.sitename,
+                        'sitedescription', sts.sitedescription,
+                        'sitenotes', sts.notes,
+                        'geography', ST_AsGeoJSON(sts.geog,5,2),
+                        'latitudesouth', ST_YMin(ST_GeomFromText(ST_AsText(sts.geog),4326)),
+                        'latitudenorth', ST_YMax(ST_GeomFromText(ST_AsText(sts.geog),4326)),
+                        'longitudeeast', ST_XMax(ST_GeomFromText(ST_AsText(sts.geog),4326)),
+                        'longitudewest', ST_XMin(ST_GeomFromText(ST_AsText(sts.geog),4326)),
+                        'altitude', sts.altitude, 
+                        'unittype', cts.colltype ) as site,
                  json_agg(
                           json_build_object(
-                             'contactid', cntct.contactid,
-                           'contactname', cntct.contactname
-                        )) as datasetpis,
+                            'contactid', cntct.contactid,
+                            'contactname', cntct.contactname
+                        ) ) as datasetpis,
                  json_agg(
                       json_build_object(
                         'submissiondate', dtssubs.submissiondate,

--- a/v1.5/helpers/datasets/datasets.js
+++ b/v1.5/helpers/datasets/datasets.js
@@ -125,6 +125,48 @@ function datasetsbysiteid(req, res, next) {
 }
 
 
+function datasetsbysiteids(req, res, next) {
+  var badstid = false;
+  var siteids = [];
+  siteids = String(req.query.siteids)
+    .split(",")
+    .map(function(item) {
+      if(NaN == parseInt(item)) {
+        badstid = true
+        //bad datasetid
+        return
+      }
+      return parseInt(item, 10)
+    });
+
+  //check if datasetid is sequence is not valid
+  if (badstid) {
+    res.status(500)
+      .jsonp({
+        success: 0,
+        status: 'failure',
+        data: null,
+        message: 'Must pass valid datasetids as integer sequence.'
+      });
+  }
+
+  db.any(datasetsbysitesql, [siteids])
+    .then(function (data) {
+      res.status(200)
+        .type('application/json')
+        .jsonp({
+          success: 1,
+          status: 'success',
+          data: data,
+          message: 'Retrieved all tables'
+        });
+    })
+    .catch(function (err) {
+      next(err);
+    });
+}
+
+
 function datasetquery(req, res, next) {
   console.log('Here')
   var datasetid = req.params.datasetid;
@@ -155,4 +197,5 @@ function datasetquery(req, res, next) {
 module.exports.datasetbyid = datasetbyid;
 module.exports.datasetbyids = datasetbyids;
 module.exports.datasetsbysiteid = datasetsbysiteid;
+module.exports.datasetsbysiteids = datasetsbysiteids;
 module.exports.datasetquery = datasetquery;


### PR DESCRIPTION
This PR makes necessary changes to the v1.5 api to enable explorer URL search for one or multiple datasets or sites.

Datasets ex.:
https://apps.neotomadb.org/explorer/?datasetids=1234
or
https://apps.neotomadb.org/explorer/?datasetids=1234,3456,234

Sites ex.:
https://apps.neotomadb.org/explorer/?siteids=12
or
https://apps.neotomadb.org/explorer/?siteids=12,123,45