### PR TITLE
OI-29 updating yarn in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM node:22-alpine
 WORKDIR /app
 RUN corepack enable
 COPY package.json yarn.lock .yarnrc.yml ./
-COPY .yarn/ ./.yarn/
 RUN yarn install --immutable
 COPY . .
 EXPOSE 3001


### PR DESCRIPTION
This pull request makes a small change to the Docker build process by removing the line that copies the `.yarn/` directory. This simplifies the Dockerfile and may improve build performance or prevent unnecessary files from being included in the image.
Also, added sign key in local machine