### PR TITLE
API-51 added allowed origin for apps

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,7 +39,7 @@ app.engine('html', require('ejs').renderFile);
 
 const {optionalAuth} = require('./v2.0/helpers/validation/sessionauth');
 const allowedOrigins = env === 'production'
-  ? ['https://data.neotomadb.org']
+  ? ['https://data.neotomadb.org', 'https://apps.neotomadb.org']
   : ['http://localhost:5173', 'http://127.0.0.1:5173'];
 
 const corsOptions = {


### PR DESCRIPTION
This pull request makes a small update to the list of allowed CORS origins in the application configuration, enabling requests from an additional production subdomain.

- Configuration update:
  * Added `https://apps.neotomadb.org` to the list of allowed CORS origins for production in `app.js`.