### PR TITLE
API-51 added allowed origin for apps

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,7 +39,7 @@ app.engine('html', require('ejs').renderFile);
 
 const {optionalAuth} = require('./v2.0/helpers/validation/sessionauth');
 const allowedOrigins = env === 'production'
-  ? ['https://data.neotomadb.org']
+  ? ['https://data.neotomadb.org', 'https://apps.neotomadb.org']
   : ['http://localhost:5173', 'http://127.0.0.1:5173'];
 
 const corsOptions = {


### PR DESCRIPTION
This pull request makes a small update to the list of allowed CORS origins in `app.js` to support an additional production domain.

* Added `https://apps.neotomadb.org` to the list of allowed origins for CORS in production, enabling cross-origin requests from this domain.